### PR TITLE
Add device simulator option to HUME when starting, device sim shall r…

### DIFF
--- a/hume/device_controller/device_controller/device/application.py
+++ b/hume/device_controller/device_controller/device/application.py
@@ -8,6 +8,7 @@ import hume_storage as storage
 from device_controller.device.http_server import MyServer
 from device_controller.device.models import Device
 from device_controller.device import routes  # noqa
+from device_controller.util.args import get_arg, TEST_RUN_DEVICE_SIMULATOR
 
 
 LOGGER = logging.getLogger(__name__)
@@ -49,6 +50,10 @@ def start():
     server_thread = threading.Thread(target=start_http_server)
     server_thread.start()
 
+    if get_arg(TEST_RUN_DEVICE_SIMULATOR):
+        from device_controller.device.simulator import start_simulator
+        start_simulator()
+
 
 def stop():
     """
@@ -58,3 +63,7 @@ def stop():
 
     server.shutdown()
     server_thread.join()
+
+    if get_arg(TEST_RUN_DEVICE_SIMULATOR):
+        from device_controller.device.simulator import stop_simulator
+        stop_simulator()

--- a/hume/device_controller/device_controller/device/device_req_lib.py
+++ b/hume/device_controller/device_controller/device/device_req_lib.py
@@ -1,7 +1,7 @@
 import logging
 import requests
 
-from device_controller.util.args import get_arg, DEVICE_MOCK_ADDRESS
+from device_controller.util.args import get_arg, TEST_DEVICE_MOCK_ADDRESS
 
 
 LOGGER = logging.getLogger(__name__)
@@ -18,7 +18,7 @@ def _device_url(device):
 
     :type device: Device
     """
-    mock_address = get_arg(DEVICE_MOCK_ADDRESS)
+    mock_address = get_arg(TEST_DEVICE_MOCK_ADDRESS)
 
     if mock_address:
         return mock_address + "/"

--- a/hume/device_controller/device_controller/device/simulator/__init__.py
+++ b/hume/device_controller/device_controller/device/simulator/__init__.py
@@ -1,0 +1,4 @@
+from device_controller.device.simulator.simulator import (
+    start_simulator,
+    stop_simulator
+)

--- a/hume/device_controller/device_controller/device/simulator/simulator.py
+++ b/hume/device_controller/device_controller/device/simulator/simulator.py
@@ -1,0 +1,127 @@
+import threading
+import time
+import requests
+import json
+import random
+
+from bottle import run, get, response
+
+from device_controller.device.http_server import MyServer
+
+
+"""
+This module implements a simple device simulator. It consists of a small web
+service which listens for capability, heartbeat, and action requests and
+replies to them as a normal device would. The device simulator simulates only
+one device, a thermometer. Upon starting the simulator, an attach request will
+be sent to HUME.
+"""
+
+
+server = MyServer(host='localhost', port=32222)
+server_thread: threading.Thread
+
+ACTION_TEMPERATURE = "0"
+ACTION_HUMIDITY = "1"
+
+
+def start_simulator():
+    """
+    Starts the device simulator web server.
+    """
+
+    def run_server():
+        """
+        Target of the server thread.
+        """
+        run(server=server)
+
+    global server_thread
+    server_thread = threading.Thread(target=run_server)
+    server_thread.start()
+
+    # Wait a bit before attaching to let HUME start
+    time.sleep(2)
+    requests.post("http://localhost:8081/devices/attach",
+                  json={"uuid": "86e467d9-02b4-4119-940d-a871750aa997"})
+
+
+def stop_simulator():
+    """
+    Stops the device simulator.
+    """
+    server.shutdown()
+    server_thread.join()
+
+
+@get('/capabilities')
+def capabilties():
+    """
+    When HUME requests the device to send its capabilities through a
+    capability request.
+
+    :returns: bottle.response
+    """
+    response.status = 200
+    response.body = json.dumps(
+        {
+            "uuid": "e2bf93b6-9b5d-4944-a863-611b6b6600e7",
+            "name": "THERMO X2",
+            "description": "Combined Thermometer and Humidity sensor.",
+            "category": 0,
+            "type": 0,
+            "data_types": {
+                "0": "Temperature",
+                "1": "Humidity"
+            },
+            "actions": [
+                {
+                    "id": 0,
+                    "name": "Read temperature",
+                    "type": 1,
+                    "data_type": "0",
+                    "return_type": 2
+
+                },
+                {
+                    "id": 1,
+                    "name": "Read humidity",
+                    "type": 1,
+                    "data_type": "1",
+                    "return_type": 2
+                }
+            ]
+        }
+    )
+
+    return response
+
+
+@get('/heartbeat')
+def heartbeat():
+    """
+    When HUME requests to see if the device is still alive.
+    """
+    # No need to fill in anything, an empty response = 200
+    pass
+
+
+@get('/actions/<action_id>')
+def action(action_id):
+    """
+    HUME wants to execute a device action.
+
+    :param action_id: points out which action to execute
+    :return: bottle.response
+    """
+    # both actions return a float, but humidity is a range between 0.0 and
+    # 100.0 while temperature is assumed to be indoor and between 19.0 and
+    # 30.0 degrees celsius.
+    if action_id == ACTION_TEMPERATURE:
+        val = random.uniform(19.0, 30.0)
+    elif action_id == ACTION_HUMIDITY:
+        val = random.uniform(0.0, 100.0)
+
+    response.body = json.dumps({"value": f"{val:.2f}"})
+
+    return response

--- a/hume/device_controller/device_controller/util/args.py
+++ b/hume/device_controller/device_controller/util/args.py
@@ -1,7 +1,15 @@
-_args = None
+"""
+This module is responsible for keeping CLI arguments stored for easy access.
+"""
+
+
+_args: dict
 
 HUME_UUID = "hume_uuid"
-DEVICE_MOCK_ADDRESS = "device_mock_address"
+
+# TESTING PARAMETERS
+TEST_DEVICE_MOCK_ADDRESS = "test_device_mock_address"
+TEST_RUN_DEVICE_SIMULATOR = "test_run_device_simulator"
 
 
 def set_args(**cli_args):

--- a/hume/device_controller/main.py
+++ b/hume/device_controller/main.py
@@ -16,16 +16,32 @@ def parse_args():
         description="HUME device controller"
     )
 
+    #
+    # Positional arguments
+    #
+
     # HUME identification
     parser.add_argument('hume_uuid',
                         metavar="HUME_UUID",
                         help="HUME UUID")
 
-    # Testing
-    parser.add_argument('-dma',
-                        '--device-mock-address',
-                        help="Set up a device mock address where all device "
-                             "requests will be routed")
+    #
+    # Optional arguments
+    #
+
+    # Testing arguments are prepended with "--test", or "-t" for short.
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument('-t-dma',
+                       '--test-device-mock-address',
+                       help="Set up a device mock address where all device "
+                            "requests will be routed")
+    group.add_argument('-t-rds',
+                       '--test-run-device-simulator',
+                       help="Run a device simulator, where a single device "
+                            "will attach to the HUME on start and can reply "
+                            "to all standard requests such as: capability, "
+                            "heartbeat, and action",
+                       action='store_true')
 
     print("Starting DC with the following arguments:")
     print(parser.parse_args())


### PR DESCRIPTION
…espond to normal

device requests and attach itself to HUME on HUME start. Useful for testing end-to-end
without having to curl all the comms.